### PR TITLE
Remove dependency on Rack

### DIFF
--- a/lib/sass/extras/svg_data_urls.rb
+++ b/lib/sass/extras/svg_data_urls.rb
@@ -1,6 +1,3 @@
-require "base64"
-require "rack"
-
 module Sass
   module Extras
     module SvgDataUrls
@@ -59,8 +56,8 @@ module Sass
       end
 
       def svg_data_url(svg)
-        base64 = Base64.encode64(svg).gsub(/\s+/, "")
-        Sass::Script::String.new("url(data:image/svg+xml;base64,#{Rack::Utils.escape(base64)})")
+        compacted = svg.gsub(/>\s+/, ">").gsub(/\s+</, "<").strip
+        Sass::Script::String.new("url('data:image/svg+xml;utf8,#{compacted}')")
       end
     end
   end

--- a/sass-extras.gemspec
+++ b/sass-extras.gemspec
@@ -20,7 +20,6 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "sass"
   spec.add_dependency "chunky_png"
-  spec.add_dependency "rack"
 
   spec.add_development_dependency "bundler", "~> 1.5"
   spec.add_development_dependency "rake"

--- a/specs/spec_helper.rb
+++ b/specs/spec_helper.rb
@@ -1,2 +1,10 @@
 require "minitest/autorun"
 require "sass/extras"
+
+def unindent(s)
+  s.gsub(/^#{s.scan(/^[ \t]+(?=\S)/).min}/, "")
+end
+
+def render(scss)
+  Sass::Engine.new(scss, syntax: :scss).render
+end

--- a/specs/svg_data_urls_spec.rb
+++ b/specs/svg_data_urls_spec.rb
@@ -1,0 +1,27 @@
+require_relative "spec_helper"
+
+describe Sass::Extras::SvgDataUrls do
+  describe "circle_image_data_url" do
+    it "renders to a data-url" do
+      render(unindent(<<-SCSS)).must_equal unindent(<<-CSS)
+        a {
+          b: circle_image_data_url(); }
+      SCSS
+        a {
+          b: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg"><circle cx="10" cy="10" r="10" fill="rgb(0,0,0)"/></svg>'); }
+      CSS
+    end
+  end
+
+  describe "radial_gradient_image_data_url" do
+    it "renders to a data-url" do
+      render(unindent(<<-SCSS)).must_equal unindent(<<-CSS)
+        a {
+          b: radial_gradient_image_data_url(); }
+      SCSS
+        a {
+          b: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg"><defs><radialGradient id="gradient"><stop offset="50%" stop-color="rgb(0,0,0)" stop-opacity="0.2"/><stop offset="100%" stop-color="rgb(0,0,0)" stop-opacity="0"/></radialGradient></defs><rect width="100%" height="10" y="-5" fill="url(#gradient)"></rect></svg>'); }
+      CSS
+    end
+  end
+end

--- a/specs/variables_spec.rb
+++ b/specs/variables_spec.rb
@@ -3,46 +3,38 @@ require_relative "spec_helper"
 describe Sass::Extras::Variables do
   describe "variable-get" do
     it "gets the value of a local variable" do
-      unindent(<<-CSS).must_equal render(unindent(<<-SCSS))
-        a {
-          b: 42; }
-      CSS
+      render(unindent(<<-SCSS)).must_equal unindent(<<-CSS)
         a {
           $my-local-var: 42;
           b: variable-get(my-local-var); }
       SCSS
-    end
-
-    it "also gets variables from the global scope" do
-      unindent(<<-CSS).must_equal render(unindent(<<-SCSS))
         a {
           b: 42; }
       CSS
+    end
+
+    it "also gets variables from the global scope" do
+      render(unindent(<<-SCSS)).must_equal unindent(<<-CSS)
         $my-global-var: 42;
         a {
           b: variable-get(my-global-var); }
       SCSS
+        a {
+          b: 42; }
+      CSS
     end
   end
 
   describe "global-variable-get" do
     it "get the value of a global variable" do
-      unindent(<<-CSS).must_equal render(unindent(<<-SCSS))
-        a {
-          b: 42; }
-      CSS
+      render(unindent(<<-SCSS)).must_equal unindent(<<-CSS)
         $my-global-var: 42;
         a {
           b: global-variable-get(my-global-var); }
       SCSS
+        a {
+          b: 42; }
+      CSS
     end
-  end
-
-  def unindent(s)
-    s.gsub(/^#{s.scan(/^[ \t]+(?=\S)/).min}/, "")
-  end
-
-  def render(scss)
-    Sass::Engine.new(scss, syntax: :scss).render
   end
 end

--- a/specs/yuv_spec.rb
+++ b/specs/yuv_spec.rb
@@ -39,37 +39,33 @@ describe Sass::Extras::YUV::Color do
 
   describe "usage in render" do
     it "can define color" do
-      <<CSS.must_equal render(<<SASS)
-a {
-  b: #1a1a1a; }
-CSS
-a {
-  b: yuv(10%, 0, 0); }
-SASS
+      render(unindent(<<-SCSS)).must_equal unindent(<<-CSS)
+        a {
+          b: yuv(10%, 0, 0); }
+      SCSS
+        a {
+          b: #1a1a1a; }
+      CSS
     end
 
     it "converts nicely" do
-      <<CSS.must_equal render(<<SASS)
-a {
-  b: #1a1a1a; }
-CSS
-a {
-  b: set-brightness(#ffffff, 10%); }
-SASS
+      render(unindent(<<-SCSS)).must_equal unindent(<<-CSS)
+        a {
+          b: set-brightness(#ffffff, 10%); }
+      SCSS
+        a {
+          b: #1a1a1a; }
+      CSS
     end
 
     it "reduces brightness" do
-      <<CSS.must_equal render(<<SASS)
-a {
-  b: #e6e6e6; }
-CSS
-a {
-  b: reduce-brightness(#ffffff, 10%); }
-SASS
+      render(unindent(<<-SCSS)).must_equal unindent(<<-CSS)
+        a {
+          b: reduce-brightness(#ffffff, 10%); }
+      SCSS
+        a {
+          b: #e6e6e6; }
+      CSS
     end
-  end
-
-  def render(sass)
-    Sass::Engine.new(sass, syntax: :scss).render
   end
 end


### PR DESCRIPTION
Rack 2.0 removed support for older Ruby versions,
and it seems like a bit much that a simple SCSS lib should depend on a framework like Rack.